### PR TITLE
로그아웃 완료

### DIFF
--- a/src/main/java/com/example/newsfeedproject/auth/controller/AuthController.java
+++ b/src/main/java/com/example/newsfeedproject/auth/controller/AuthController.java
@@ -68,7 +68,7 @@ public class AuthController {
                 .path("/api/auth/refresh")
                 .maxAge(0)
                 .build();
-        return ResponseEntity.noContent()
+        return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
                 .build();
     }

--- a/src/main/java/com/example/newsfeedproject/auth/controller/AuthController.java
+++ b/src/main/java/com/example/newsfeedproject/auth/controller/AuthController.java
@@ -55,5 +55,22 @@ public class AuthController {
                 .body(new SigninResponseDto(tokens.getAccessToken(), tokens.getRefreshToken()));
     }
     //TODO: 로그아웃
+    @PostMapping("/signout")
+    public ResponseEntity<Void> signout() {
+        // refreshToken= : 값 비움
+        //Max-Age=0 + Expires=Thu, 01 Jan 1970…: 즉시 만료
+        //Path=/api/auth/refresh: 쿠키만 삭제
+        // HttpOnly; SameSite=Strict: 아래 옵션 맞춰서 제거
+        ResponseCookie deleteCookie =ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Strict")
+                .path("/api/auth/refresh")
+                .maxAge(0)
+                .build();
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
+                .build();
+    }
 
 }


### PR DESCRIPTION
POST맨에서 
로그인 먼저 하시고 나서 
http://localhost:8080/api/auth/signout 경로로 그냥 send 해보시면 200OK가 확인 됩니다

Cookies 클릭하면 리프레시 사라지는 걸 보실 수 있습니당

코드 간단 설명

```java
@PostMapping("/signout")
    public ResponseEntity<Void> signout() {
        // refreshToken= : 값 비움
        //Max-Age=0 + Expires=Thu, 01 Jan 1970…: 즉시 만료
        //Path=/api/auth/refresh: 쿠키만 삭제
        // HttpOnly; SameSite=Strict: 아래 옵션 맞춰서 제거
        ResponseCookie deleteCookie =ResponseCookie.from("refreshToken", "")
                .httpOnly(true)
                .secure(false)
                .sameSite("Strict")
                .path("/api/auth/refresh")
                .maxAge(0)
                .build();
        return ResponseEntity.ok()
                .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
                .build();
    }
```

로그인 했을 때랑 양식? 똑같이 맞춰서 쿠키만 삭제하는 로직입니다