### PR TITLE
JWT 인증필터(JwtAuthorizationFilter) 전역으로 옮김

### DIFF
--- a/src/main/java/com/example/newsfeedproject/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/newsfeedproject/common/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.example.newsfeedproject.common.config;
 
-import com.example.newsfeedproject.auth.filter.JwtAuthorizationFilter;
+import com.example.newsfeedproject.common.filter.JwtAuthorizationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/example/newsfeedproject/common/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/newsfeedproject/common/filter/JwtAuthorizationFilter.java
@@ -1,4 +1,4 @@
-package com.example.newsfeedproject.auth.filter;
+package com.example.newsfeedproject.common.filter;
 
 
 import com.example.newsfeedproject.auth.impl.UserDetailsImpl;


### PR DESCRIPTION
JWT 인증 필터(JwtAuthorizationFilter)
모든 요청이 컨트롤러에 들어오기 전에 동작해서
토큰을 검사하고
인증 정보를 SecurityContext에 넣어주는 역할입니다

특정 도메인(예: auth)에 종속되지 않고, 프로젝트 전반에 걸쳐 필요한 기능이기 때문에 common으로 빼두었습니다



