### PR TITLE
🐛 fix : 유저 게시글 조회 기능 버그 수정

### DIFF
--- a/src/main/java/com/example/newsfeedproject/likes/repository/LikesRepository.java
+++ b/src/main/java/com/example/newsfeedproject/likes/repository/LikesRepository.java
@@ -32,9 +32,9 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
             "GROUP BY l.feedId")             // FeedId 별로 그룹화
     List<Object[]> countLikedByFeedIds(@Param("feedIds") List<Long> feedIds);
 
-    @Query("SELECT l.feedId " +
+    @Query("SELECT l.feedId, l.liked " +
             "FROM Likes l " +                // Likes Table as l
-            "WHERE l.feedId IN :feedIds AND l.userId = :userId AND l.liked = true " +  // feedIds 리스트 IN AND Likes Table의 liked = true 값
-            "GROUP BY l.feedId")
-    List<Object []> isLikedByFeedIdsANDUserId(@Param("feedIds") List<Long> feedIds, Long userId);
+            "WHERE l.feedId IN :feedIds AND l.userId = :userId "  // feedIds 리스트 IN AND Likes Table의 liked = true 값
+            )
+    List<Object []> isLikedByFeedIdsANDUserId(@Param("feedIds") List<Long> feedIds, @Param("userId") Long userId);
 }

--- a/src/main/java/com/example/newsfeedproject/users/service/UsersService.java
+++ b/src/main/java/com/example/newsfeedproject/users/service/UsersService.java
@@ -70,15 +70,15 @@ public class UsersService {
 
         //null 값 때문에 Object로 받고 Map으로 key: feedId, value: count한 like값
         Map<Long, Integer> likeTotal =likeRepository.countLikedByFeedIds(feedIds).stream()
-                                        .collect(Collectors.toMap(row ->(Long) row[0], row ->(Integer) row[1]));
+                                        .collect(Collectors.toMap(row ->(Long) row[0], row ->((Long) row[1]).intValue()));
 
         //null 값 때문에 Object로 받고 Map으로 Key: feedId, value: count한 comments값
         Map<Long, Integer> commentsTotal = commentsRepository.countCommentsByFeedIds(feedIds).stream()
-                                            .collect(Collectors.toMap(row ->(Long) row[0], row ->(Integer) row[1]));
+                                            .collect(Collectors.toMap(row ->(Long) row[0], row ->((Long) row[1]).intValue()));
 
 
         // null 값 때문에 Object로 받고 Map으로 Key: feedId, value: liked true값
-        Map<Long, Boolean> liked = likeRepository.isLikedByFeedIdsANDUserId(feedIds, userId).stream()
+        Map<Long, Boolean> liked = likeRepository.isLikedByFeedIdsANDUserId(feedIds, principalRequestDto.getUserId()).stream()
                                         .collect(Collectors.toMap(row->(Long) row[0], row ->(Boolean) row[1]));
 
 


### PR DESCRIPTION
게시글 좋아요를 진행하면서 상대 유저 게시글 조회 기능에서 테스트를 하던 도중
1. 게시글 좋아요 값이 로그인해서 보는유저(본인)가 아닌 게시글을 올린 유저(상대) 입장에서 나타나서 조건용 userId 값 변경

2. Query에서 FeedId별로 Liked 값을 받아와야하는데 Liked값 생략 된거 추가, 필요없는 조건문 삭제
3. Map 과정에서 Long->Integer 변환과정 문제 해결
